### PR TITLE
docs(README): add Installation, Quick Start, API overview, and TypeScript types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,98 @@
 # LinkedList
 
 <!-- prettier-ignore -->
-> A typescript array-like doubly linked list.
+> A TypeScript array-like doubly linked list.
 >
 > [![NPM Version][npm-image]][npm-url]
 > [![Download Status][download-image]][npm-url]
 > [![License][license-image]][license-url]
 
-### API
+An **array-like doubly linked list** implementation for TypeScript. It mirrors common `Array` usage patterns while keeping efficient linked-list node operations and `for...of` iteration support.
 
-[See MDN Array API](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Array)
+## Installation
+
+```bash
+pnpm add @nuintun/linked-list
+# or
+npm i @nuintun/linked-list
+```
+
+## Quick Start
+
+```ts
+import { LinkedList } from '@nuintun/linked-list';
+
+const list = new LinkedList<number>([1, 2, 3]);
+
+list.push(4); // [1, 2, 3, 4]
+list.unshift(0); // [0, 1, 2, 3, 4]
+
+console.log(list.at(-1)); // 4
+console.log(list.length); // 5
+console.log([...list]); // [0, 1, 2, 3, 4]
+```
+
+## Features
+
+- Array-like mutation methods: `push / pop / shift / unshift / splice / slice / concat`
+- Lookup methods: `at / includes / indexOf / lastIndexOf / find / findIndex`
+- Functional methods: `map / filter / every / some / forEach`
+- Iteration & conversion: `values / Symbol.iterator / valueOf / toString / join`
+- Full TypeScript type support
+
+## API Overview
+
+> For method semantics, see MDN Array docs: [MDN Array API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+
+### Constructor
+
+- `new LinkedList<T>(iterable?: Iterable<T>)`
+
+### Mutating Methods
+
+- `unshift(...values: T[]): number`
+- `shift(): T | undefined`
+- `push(...values: T[]): number`
+- `pop(): T | undefined`
+- `splice(fromIndex: number, removedLength?: number, ...values: T[]): T[]`
+- `reverse(): LinkedList<T>`
+
+### Read & Query Methods
+
+- `at(index: number): T | undefined`
+- `includes(value: T, fromIndex?: number): boolean`
+- `indexOf(value: T, fromIndex?: number): number`
+- `lastIndexOf(value: T, fromIndex?: number): number`
+- `find(callback, context?): T | undefined`
+- `findIndex(callback, context?): number`
+- `slice(fromIndex?: number, toIndex?: number): LinkedList<T>`
+- `concat(...sources: LinkedList<T>[]): LinkedList<T>`
+- `get length(): number`
+
+### Iteration & Transformation
+
+- `forEach(callback, context?): void`
+- `map<U>(callback, context?): LinkedList<U>`
+- `filter(callback, context?): LinkedList<T>`
+- `every(callback, context?): boolean`
+- `some(callback, context?): boolean`
+- `join(separator?: string): string`
+- `values(): Iterator<T>`
+- `[Symbol.iterator](): Iterator<T>`
+- `valueOf(): T[]`
+- `toString(): string`
+
+## Type Definition
+
+```ts
+export interface Callback<T, R = boolean> {
+  (value: T, index: number, source: LinkedList<T>): R;
+}
+```
+
+## License
+
+[MIT](./LICENSE)
 
 [npm-image]: https://img.shields.io/npm/v/@nuintun/linked-list?style=flat-square
 [npm-url]: https://www.npmjs.org/package/@nuintun/linked-list


### PR DESCRIPTION
### Motivation

- Clarify the project purpose and improve developer onboarding by expanding the README into a full usage and API reference.
- Provide concrete installation and usage examples so TypeScript users can quickly adopt the linked-list implementation.
- Document the public API and types to mirror familiar `Array` semantics while highlighting the linked-list features.

### Description

- Rewrote the project description to `TypeScript` and expanded the one-line README into sections including `Installation`, `Quick Start`, `Features`, and `API Overview`.
- Added a `Quick Start` example showing import, basic mutations, `at` lookup, `length`, and iteration using `...list` and `for...of` semantics.
- Documented available methods (mutating, lookup, iteration, and transformation) and included a `Callback` type definition snippet for TypeScript consumers.
- Updated the MDN Array link to the English docs and kept license/badge references intact.

### Testing

- No automated tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cce36b5798833381de9b0792231a49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Comprehensively updated README with installation instructions and quick-start usage examples
* Expanded API reference with TypeScript documentation for constructors, methods, and type definitions
* Added dedicated License section for clearer legal reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->